### PR TITLE
Added -UseBasicParsing switch to Invoke-WebRequest

### DIFF
--- a/Find-Domain.ps1
+++ b/Find-Domain.ps1
@@ -43,14 +43,14 @@ function Find-Domain
         $Headers = @{}
         $Headers["Authorization"] = 'sso-key ' + $apiKey.key + ':' + $apiKey.secret
 
-        $Available = Invoke-WebRequest https://api.godaddy.com/v1/domains/available?domain=$Domain -Method Get -Headers $Headers | ConvertFrom-Json
+        $Available = Invoke-WebRequest https://api.godaddy.com/v1/domains/available?domain=$Domain -Method Get -Headers $Headers -UseBasicParsing | ConvertFrom-Json
 
             if($Available.available -eq 'True'){
                 Write-Host "$Domain is available!"}
             else{
                 Write-Host "$Domain is already taken."
                 
-                $Suggestions = Invoke-WebRequest https://api.godaddy.com/v1/domains/suggest?query=$Domain -Method Get -Headers $Headers | ConvertFrom-Json
+                $Suggestions = Invoke-WebRequest https://api.godaddy.com/v1/domains/suggest?query=$Domain -Method Get -Headers $Headers -UseBasicParsing | ConvertFrom-Json
                 $Suggestions | Get-Random -Count 15 | Format-Table @{e={$_.domain};l="Alternate Domains"}}
     }
     End

--- a/Get-GoDaddyCert.ps1
+++ b/Get-GoDaddyCert.ps1
@@ -38,7 +38,7 @@ function Get-GoDaddyCert
         $Headers["Authorization"] = 'sso-key ' + $apiKey.key + ':' + $apiKey.secret
         
         try{
-            $Certs = Invoke-WebRequest https://api.godaddy.com/v1/Certificates/$CertID -Method Get -Headers $Headers | ConvertFrom-Json
+            $Certs = Invoke-WebRequest https://api.godaddy.com/v1/Certificates/$CertID -Method Get -Headers $Headers -UseBasicParsing | ConvertFrom-Json
         }
         catch [System.Net.WebException]{
             Write-Error 'API key and/or secret is incorrect for Get-GoDaddyDNS.'

--- a/Get-GoDaddyDNS.ps1
+++ b/Get-GoDaddyDNS.ps1
@@ -50,7 +50,7 @@ function Get-GoDaddyDNS
         $Headers["Authorization"] = 'sso-key ' + $apiKey.key + ':' + $apiKey.secret
         
         try{
-            Invoke-WebRequest https://api.godaddy.com/v1/domains/$Domain/records/$Type/$Name -Method Get -Headers $Headers | ConvertFrom-Json
+            Invoke-WebRequest https://api.godaddy.com/v1/domains/$Domain/records/$Type/$Name -Method Get -Headers $Headers -UseBasicParsing | ConvertFrom-Json
         }
         catch [System.Net.WebException]{
             Write-Error 'API key and/or secret is incorrect for Get-GoDaddyDNS.'

--- a/Set-GoDaddyDNS.ps1
+++ b/Set-GoDaddyDNS.ps1
@@ -48,7 +48,7 @@ function Set-GoDaddyDNS
         $Body = ConvertTo-Json $Record
 
         try{
-            Invoke-WebRequest https://api.godaddy.com/v1/domains/$Domain/records/$Type/$Name -Method Put -Headers $Headers -Body $Body -ContentType "application/json" | Out-Null
+            Invoke-WebRequest https://api.godaddy.com/v1/domains/$Domain/records/$Type/$Name -Method Put -Headers $Headers -Body $Body -ContentType "application/json" -UseBasicParsing | Out-Null
         }
         catch [System.Net.WebException]{
             Write-Error 'API key and/or secret is incorrect for Set-GoDaddyDNS.'


### PR DESCRIPTION
This resolves the following error when executing `Invoke-WebRequest`:

> The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.