### PR TITLE
Output object

### DIFF
--- a/Add-GoDaddyDNS.ps1
+++ b/Add-GoDaddyDNS.ps1
@@ -144,9 +144,10 @@ function Add-GoDaddyDNS
             $body = "[" + (ConvertTo-Json $record) + "]"
         }
 
-        Invoke-WebRequest https://api.godaddy.com/v1/domains/$Domain/records -Method Patch -Headers $headers -Body $body -UseBasicParsing | ConvertFrom-Json
+        $uri = "https://api.godaddy.com/v1/domains/$Domain/records"
+        Invoke-WebRequest -Uri $uri -Method Patch -Headers $headers -Body $body -UseBasicParsing | ConvertFrom-Json
 
-        Get-GoDaddyDNS -Domain $Domain -Type $Type -Name $Name
+        Get-GoDaddyDNS -Domain $Domain | Where-Object {$_.type -eq $Type -and $_.name -eq $Name}
     }
     End
     {

--- a/README.md
+++ b/README.md
@@ -97,19 +97,6 @@ type name data         ttl
 A    test 10.10.10.12 3600
 ```
 
-And confirmed with `Get-GoDaddyDNS`:
-
-``` console
-PS C:\> Get-GoDaddyDNS clintcolding.com
-
-type  name           data                                                                  ttl
-----  ----           ----                                                                  ---
-A     @              192.30.252.153                                                        600
-A     @              192.30.252.154                                                        600
-A     test           10.10.10.12                                                          3600
-CNAME www            @                                                                    3600
-```
-
 ### Adding and Setting SRV Records
 
 When adding or setting SRV records, additional parameters are required. (Service, Priority, Protocol, Port, Weight)
@@ -139,5 +126,5 @@ PS C:\> Get-GoDaddyDNS clintcolding.com
 
 type  name  data                              ttl
 ----  ----  ----                              ---
-SRV   test  targethost.test.clintcolding.com  3600
+SRV   test  targethost.clintcolding.com  3600
 ```

--- a/README.md
+++ b/README.md
@@ -44,27 +44,6 @@ A     @              192.30.252.154                                             
 CNAME www            @                                                                    3600
 ```
 
-You can also filter by type:
-
-``` console
-PS C:\> Get-GoDaddyDNS clintcolding.com -Type A
-
-type name data           ttl
----- ---- ----           ---
-A    @    192.30.252.153 600
-A    @    192.30.252.154 600
-```
-
-Or by type **AND** name:
-
-``` console
-PS C:\> Get-GoDaddyDNS clintcolding.com -Type CNAME -Name 'www'
-
-type  name data  ttl
-----  ---- ----  ---
-CNAME www  @    3600
-```
-
 ### Using Add-GoDaddyDNS
 
 `Add-GoDaddyDNS` allows you to create new DNS records. Below we'll create a new A record for test.clintcolding.com with an Data of 10.10.10.10:


### PR DESCRIPTION
`Get-GoDaddyDNS` now outputs a psobject and no longer accepts Type or Name as filters.

**This is a breaking change**, to filter pipe your results to `Where-Object`.

`Get-GoDaddyDNS clintcolding.com | Where-Object {$_.Type -eq "A"}`
`Get-GoDaddyDNS clintcolding.com | Where-Object {$_.Name -eq "@"}`
`Get-GoDaddyDNS clintcolding.com | Where-Object {$_.Type -eq "A" -and $_.Name -eq "@"}`