### PR TITLE
Encrypt API Keys saved in CSV

### DIFF
--- a/Add-GoDaddyDNS.ps1
+++ b/Add-GoDaddyDNS.ps1
@@ -126,7 +126,15 @@ function Add-GoDaddyDNS
 
     Begin
     {
-        $apiKey = Import-Csv "$PSScriptRoot\apiKey.csv"
+        $apiKeySecure = Import-Csv "$PSScriptRoot\apiKey.csv"
+
+        # Decrypt API Key
+        $apiKey = @(
+            [PSCustomObject]@{
+                Key = [System.Net.NetworkCredential]::new("", ($apiKeySecure.Key | ConvertTo-SecureString)).Password
+                Secret = [System.Net.NetworkCredential]::new("", ($apiKeySecure.Secret | ConvertTo-SecureString)).Password
+            }
+        )
     }
     Process
     {

--- a/Get-GoDaddyAPIKey.ps1
+++ b/Get-GoDaddyAPIKey.ps1
@@ -26,7 +26,18 @@ function Get-GoDaddyAPIKey
         ## Test if apiKey.csv exists, if so, return the contents.
 
         if ((Test-Path "$PSScriptRoot\apiKey.csv") -eq $True) {
-            Import-Csv "$PSScriptRoot\apiKey.csv"
+            $apiKeySecure = Import-Csv "$PSScriptRoot\apiKey.csv"
+
+            # Decrypt API Key
+            $apiKey = @(
+                [PSCustomObject]@{
+                    Key = [System.Net.NetworkCredential]::new("", ($apiKeySecure.Key | ConvertTo-SecureString)).Password
+                    Secret = [System.Net.NetworkCredential]::new("", ($apiKeySecure.Secret | ConvertTo-SecureString)).Password
+                }
+            )
+
+            # Return decrypted key info
+            $apiKey
         }
 
         ## If Test-Path fails, write the following warning:

--- a/Get-GoDaddyDNS.ps1
+++ b/Get-GoDaddyDNS.ps1
@@ -22,7 +22,15 @@ function Get-GoDaddyDNS
     )
 
     Begin {
-        $apiKey = Import-Csv "$PSScriptRoot\apiKey.csv"
+        $apiKeySecure = Import-Csv "$PSScriptRoot\apiKey.csv"
+
+        # Decrypt API Key
+        $apiKey = @(
+            [PSCustomObject]@{
+                Key = [System.Net.NetworkCredential]::new("", ($apiKeySecure.Key | ConvertTo-SecureString)).Password
+                Secret = [System.Net.NetworkCredential]::new("", ($apiKeySecure.Secret | ConvertTo-SecureString)).Password
+            }
+        )
     }
     Process {
         #---- Build authorization header ----#

--- a/Set-GoDaddyAPIKey.ps1
+++ b/Set-GoDaddyAPIKey.ps1
@@ -31,14 +31,18 @@ function Set-GoDaddyAPIKey
     }
     Process
     {
-        $apiKey = @(
+        # Encrypt API Key
+        $SecureKey = $Key | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
+        $SecureSecret = $Secret | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString
+
+        $apiKeySecure = @(
             [PSCustomObject]@{
-                Key = "$Key"
-                Secret = "$Secret"
+                Key = "$SecureKey"
+                Secret = "$SecureSecret"
             }
         )
         
-        $apiKey | Export-Csv -Path "$PSScriptRoot\apiKey.csv"
+        $apiKeySecure | Export-Csv -Path "$PSScriptRoot\apiKey.csv"
     }
     End
     {


### PR DESCRIPTION
Hi Clint! This module is awesome and already used by a teammate but I was concerned that the API keys are saved in a plaintext CSV file. Our domains and the services they are associated with are extremely valuable to us and in the off chance a computer is compromised, we want to minimize the chance of these resources being affected.

I modified the 4 relevant files to encrypt the API key and secret as a secure strings within the CSV. The encryption/decryption was inspired by this article: https://purple.telstra.com.au/blog/using-saved-credentials-securely-in-powershell-scripts

It might be nice to break out the decryption code into a separate helper function, but I wanted to keep the module as close as possible to how it was designed.

Thanks for reviewing this pull request!